### PR TITLE
Solved: use entity name rather than TableName?

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ public class BloggingContext : DbContext
 bloggingContext.EnsureAutoHistory()
 ```
 
-# Intergrate AutoHistory into other Package
+# Integrate AutoHistory into other Package
 
-[Microsoft.EntityFrameworkCore.UnitOfWork](https://github.com/lovedotnet/UnitOfWork) had intergrated this package.
+[Microsoft.EntityFrameworkCore.UnitOfWork](https://github.com/lovedotnet/UnitOfWork) had integrated this package.
 
 
 

--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/AutoHistory.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/AutoHistory.cs
@@ -26,6 +26,12 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <value>The name of the table.</value>
         public string TableName { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the json about the state of entity before of the change.
+        /// </summary>
+        /// <value>The json before the changing.</value>
+        public string BeforeChange { get; set; }
 
         /// <summary>
         /// Gets or sets the json about the changing.
@@ -44,5 +50,17 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <value>The create time.</value>
         public DateTime Created { get; set; } = DateTime.UtcNow;
+
+        /// <summary>
+        /// Gets or sets the creator of the change.
+        /// </summary>
+        /// <value>The createor name or email.</value>
+        public string CreatedBy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user's IP address from where the change was done.
+        /// </summary>
+        /// <value>The IP address.</value>
+        public string IPAddress { get; set; }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/AutoHistory.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/AutoHistory.cs
@@ -25,6 +25,12 @@ namespace Microsoft.EntityFrameworkCore
         /// Gets or sets the name of the table.
         /// </summary>
         /// <value>The name of the table.</value>
+        public string TableName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the entity.
+        /// </summary>
+        /// <value>The name of the entity.</value>
         public string EntityName { get; set; }
         
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/AutoHistory.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/AutoHistory.cs
@@ -56,17 +56,5 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <value>The create time.</value>
         public DateTime Created { get; set; } = DateTime.UtcNow;
-
-        /// <summary>
-        /// Gets or sets the creator of the change.
-        /// </summary>
-        /// <value>The createor name or email.</value>
-        public string CreatedBy { get; set; }
-
-        /// <summary>
-        /// Gets or sets the user's IP address from where the change was done.
-        /// </summary>
-        /// <value>The IP address.</value>
-        public string IPAddress { get; set; }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/AutoHistory.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/AutoHistory.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore
         /// Gets or sets the name of the table.
         /// </summary>
         /// <value>The name of the table.</value>
-        public string TableName { get; set; }
+        public string EntityName { get; set; }
         
         /// <summary>
         /// Gets or sets the json about the state of entity before of the change.

--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/DbContextExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/DbContextExtensions.cs
@@ -36,7 +36,8 @@ namespace Microsoft.EntityFrameworkCore
         {
             var history = new AutoHistory
             {
-                EntityName = entry.Metadata.Relational().TableName,
+                TableName = entry.Metadata.Relational().TableName,
+                EntityName = entry.Entity.GetType().Name,
                 CreatedBy = creator,
                 IPAddress = ipAddress
             };

--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/DbContextExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/DbContextExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             var history = new AutoHistory
             {
-                TableName = entry.Entity.GetType().Name,//entry.Metadata.Relational().TableName,
+                TableName = entry.Entity.GetType().Name,
                 CreatedBy = creator,
                 IPAddress = ipAddress
             };

--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/DbContextExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/DbContextExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             var history = new AutoHistory
             {
-                TableName = entry.Entity.GetType().Name,
+                EntityName = entry.Metadata.Relational().TableName,
                 CreatedBy = creator,
                 IPAddress = ipAddress
             };

--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/ModelBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/ModelBuilderExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore
             modelBuilder.Entity<AutoHistory>(b =>
             {
                 b.Property(c => c.RowId).IsRequired().HasMaxLength(50);
-                b.Property(c => c.TableName).IsRequired().HasMaxLength(128);
+                b.Property(c => c.EntityName).IsRequired().HasMaxLength(128);
                 b.Property(c => c.Changed).HasMaxLength(2048);
                 // This MSSQL only
                 //b.Property(c => c.Created).HasDefaultValueSql("getdate()");

--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/Microsoft.EntityFrameworkCore.AutoHistory.csproj
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/Microsoft.EntityFrameworkCore.AutoHistory.csproj
@@ -16,6 +16,7 @@
     <RepositoryUrl>https://github.com/arch/AutoHistory.git</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="EntityFrameworkCore.Triggers" Version="1.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.0" />

--- a/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/AutoHistoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/AutoHistoryTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.AutoHistory.Test
                     }
                 });
 
-                db.EnsureAutoHistory();
+                db.EnsureAutoHistory("xxx@example.com", "127.0.0.1");
 
                 var count = db.ChangeTracker.Entries().Count(e => e.State == EntityState.Added);
 
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.AutoHistory.Test
                 db.SaveChanges();
 
                 blog.Posts[0].Content = "UpdatedPost";
-                db.EnsureAutoHistory();
+                db.EnsureAutoHistory(null, "xxx@example.com");
                 var count = db.ChangeTracker.Entries().Count(e => e.State == EntityState.Added);
 
                 Assert.Equal(1, count);

--- a/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/AutoHistoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/AutoHistoryTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.AutoHistory.Test
                     }
                 });
 
-                db.EnsureAutoHistory("xxx@example.com", "127.0.0.1");
+                db.EnsureAutoHistory("pepito@gmail.com", "127.0.0.1");
 
                 var count = db.ChangeTracker.Entries().Count(e => e.State == EntityState.Added);
 

--- a/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/AutoHistoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/AutoHistoryTest.cs
@@ -25,6 +25,7 @@ namespace Microsoft.EntityFrameworkCore.AutoHistory.Test
                 db.EnsureAutoHistory("pepito@gmail.com", "127.0.0.1");
 
                 var count = db.ChangeTracker.Entries().Count(e => e.State == EntityState.Added);
+                
 
                 Assert.Equal(2, count);
             }

--- a/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/AutoHistoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/AutoHistoryTest.cs
@@ -21,8 +21,7 @@ namespace Microsoft.EntityFrameworkCore.AutoHistory.Test
                         }
                     }
                 });
-
-                db.EnsureAutoHistory("pepito@gmail.com", "127.0.0.1");
+                db.EnsureAutoHistory();
 
                 var count = db.ChangeTracker.Entries().Count(e => e.State == EntityState.Added);
                 
@@ -41,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.AutoHistory.Test
                     Posts = new List<Post> {
                         new Post {
                             Title = "xUnit",
-                            Content = "Post from xUnit test."
+                            //Content = "Post from xUnit test."
                         }
                     }
                 };
@@ -49,8 +48,8 @@ namespace Microsoft.EntityFrameworkCore.AutoHistory.Test
                 db.SaveChanges();
 
                 blog.Posts[0].Content = "UpdatedPost";
-                db.EnsureAutoHistory(null, "xxx@example.com");
-                var count = db.ChangeTracker.Entries().Count(e => e.State == EntityState.Added);
+                db.EnsureAutoHistory();
+                var count = db.ChangeTracker.Entries().Count(e => e.State == EntityState.Modified);
 
                 Assert.Equal(1, count);
             }

--- a/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/BloggingContext.cs
+++ b/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/BloggingContext.cs
@@ -1,31 +1,41 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EntityFrameworkCore.Triggers;
 
-namespace Microsoft.EntityFrameworkCore.AutoHistory.Test {
-    public class BloggingContext : DbContext {
+namespace Microsoft.EntityFrameworkCore.AutoHistory.Test
+{
+    public class BloggingContext : DbContext
+    {
         public DbSet<Blog> Blogs { get; set; }
         public DbSet<Post> Posts { get; set; }
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
             optionsBuilder.UseInMemoryDatabase("test");
         }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder) {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
             modelBuilder.EnableAutoHistory();
         }
     }
 
-    public class Blog {
+    public class Blog
+    {
         public int BlogId { get; set; }
         public string Url { get; set; }
 
         public List<Post> Posts { get; set; }
     }
 
-    public class Post {
+    public class Post
+    {
         public int PostId { get; set; }
         public string Title { get; set; }
         public string Content { get; set; }
-
+        public int? NumViews { get; set; } = null;
         public int BlogId { get; set; }
         public Blog Blog { get; set; }
     }

--- a/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/Microsoft.EntityFrameworkCore.AutoHistory.Test.csproj
+++ b/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/Microsoft.EntityFrameworkCore.AutoHistory.Test.csproj
@@ -8,6 +8,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="EntityFrameworkCore.Triggers" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />


### PR DESCRIPTION
I did these changes. Open to your opinion and suggestions. I want to afford in good terms.
1. Using `string EntityName = entry.Entity.GetType().Name ` as a property for AutoHistory entity.
2. I added serializing configurations using a JsonSerializer object, supporting null values in properties and ignoring reference loops.