### PR TITLE
Allow overriding the default maximum length for the Changed column.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/ModelBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/ModelBuilderExtensions.cs
@@ -11,14 +11,19 @@ namespace Microsoft.EntityFrameworkCore
         /// Enables the automatic recording change history.
         /// </summary>
         /// <param name="modelBuilder">The <see cref="ModelBuilder"/> to enable auto history functionality.</param>
+        /// <param name="changedMaxLength">The maximum length of the 'Changed' column. Use 0 to remove the max length restriction, to use nvarchar(max).</param>
         /// <returns>The <see cref="ModelBuilder"/> to enable auto history functionality.</returns>
-        public static ModelBuilder EnableAutoHistory(this ModelBuilder modelBuilder)
+        public static ModelBuilder EnableAutoHistory(this ModelBuilder modelBuilder, int? changedMaxLength = 2048)
         {
             modelBuilder.Entity<AutoHistory>(b =>
             {
                 b.Property(c => c.RowId).IsRequired().HasMaxLength(50);
                 b.Property(c => c.TableName).IsRequired().HasMaxLength(128);
-                b.Property(c => c.Changed).HasMaxLength(2048);
+                var changedProperty = b.Property(c => c.Changed);
+                if (changedMaxLength.HasValue)
+                {
+                    changedProperty.HasMaxLength(changedMaxLength.Value);
+                }
                 // This MSSQL only
                 //b.Property(c => c.Created).HasDefaultValueSql("getdate()");
             });

--- a/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/BloggingContext.cs
+++ b/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/BloggingContext.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.AutoHistory.Test
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.EnableAutoHistory();
+            modelBuilder.EnableAutoHistory(changedMaxLength: null);
         }
     }
 


### PR DESCRIPTION
This is related to issue https://github.com/Arch/AutoHistory/issues/13. It looks like there is already a pull request for this issue. Mine is a bit different in that it preserves the current behavior (max length is 2048) as the default. This means that if you were already using the AutoHistory feature and are happy with the 2048 max length you won't have to create/run any migrations when you update to the latest version of the AuthHistory package. With my change you have to opt in to using another max length, e.g. by passing null for the max length parameter you get an nvarchar(max).  

I'm happy with either fix!