### PR TITLE
Made JsonSerializerSettings for the Changed table accessible to the options.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/AutoHistoryOptions.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/AutoHistoryOptions.cs
@@ -1,11 +1,29 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.EntityFrameworkCore.Internal
 {
-    public class AutoHistoryOptions
+    /// <summary>
+    /// This class provides options for setting up auto history.
+    /// </summary>
+    public sealed class AutoHistoryOptions
     {
+        /// <summary>
+        /// The shared instance of the AutoHistoryOptions.
+        /// </summary>
+        internal static AutoHistoryOptions Instance { get; } = new AutoHistoryOptions();
+
+        /// <summary>
+        /// Prevent constructor from being called eternally.
+        /// </summary>
+        private AutoHistoryOptions()
+        {
+
+        }
+
         /// <summary>
         /// The maximum length of the 'Changed' column. <c>null</c> will use default setting 2048 unless ChangedVarcharMax is true
         /// in which case the column will be varchar(max). Default: null.
@@ -27,5 +45,21 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// The max length for the table column. Default: 128.
         /// </summary>
         public int TableMaxLength { get; set; } = 128;
+
+        /// <summary>
+        /// Set the formatting used when serializing json. Default: Formatting.None.
+        /// </summary>
+        public JsonSerializerSettings JsonSerializerSettings { get; set; } = new JsonSerializerSettings()
+        {
+            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            Formatting = Formatting.None,
+            NullValueHandling = NullValueHandling.Ignore
+        };
+
+        /// <summary>
+        /// The json serializer to use when writing changes. Created internally.
+        /// </summary>
+        internal JsonSerializer JsonSerializer { get; set; }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/AutoHistoryOptions.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/AutoHistoryOptions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public int TableMaxLength { get; set; } = 128;
 
         /// <summary>
-        /// Set the formatting used when serializing json. Default: Formatting.None.
+        /// The JsonSerializerSettings for the changed column.
         /// </summary>
         public JsonSerializerSettings JsonSerializerSettings { get; set; } = new JsonSerializerSettings()
         {

--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/ModelBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/ModelBuilderExtensions.cs
@@ -2,6 +2,8 @@
 
 using System;
 using Microsoft.EntityFrameworkCore.Internal;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -30,8 +32,9 @@ namespace Microsoft.EntityFrameworkCore
         public static ModelBuilder EnableAutoHistory<TAutoHistory>(this ModelBuilder modelBuilder, Action<AutoHistoryOptions> configure)
             where TAutoHistory : AutoHistory
         {
-            var options = new AutoHistoryOptions();
+            var options = AutoHistoryOptions.Instance;
             configure?.Invoke(options);
+            options.JsonSerializer = JsonSerializer.Create(options.JsonSerializerSettings);
 
             modelBuilder.Entity<TAutoHistory>(b =>
             {


### PR DESCRIPTION
Hi,

As requested I added the ability to control the JsonSerializerSettings for the changed table to the options. I went with the singleton options implementation as this keeps the nice clean interface you guys came up with. The JsonSerializer itself was also moved into the options, but it is internal. Because of the singleton there is still only one instance of all of this, so it is effectively the same as it was.