### PR TITLE
Update to EntityFrameworkCore 2.1

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/Microsoft.EntityFrameworkCore.AutoHistory.csproj
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/Microsoft.EntityFrameworkCore.AutoHistory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A plugin for Microsoft.EntityFrameworkCore to support automatically recording data changes history.</Description>
-    <VersionPrefix>2.0.3</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <Authors>rigofunc;rigofunc@outlook.com</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
@@ -17,6 +17,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/Microsoft.EntityFrameworkCore.AutoHistory.Test.csproj
+++ b/test/Microsoft.EntityFrameworkCore.AutoHistory.Test/Microsoft.EntityFrameworkCore.AutoHistory.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Microsoft.EntityFrameworkCore.AutoHistory.Test</AssemblyName>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>


### PR DESCRIPTION
We're using AutoHistory for a project at work and would like to update to Entity Framework 2.1