### PR TITLE
Use Equals to compare OriginalValue and CurrentValue

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/DbContextExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/DbContextExtensions.cs
@@ -80,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore
                         {
                             if (prop.OriginalValue != null)
                             {
-                                if (prop.OriginalValue != prop.CurrentValue)
+                                if (!prop.OriginalValue.Equals(prop.CurrentValue))
                                 {
                                     bef[prop.Metadata.Name] = JToken.FromObject(prop.OriginalValue, jsonSerializer);
                                 }


### PR DESCRIPTION
OriginalValue and CurrentValue are objects. Equal value types that are boxed are not equal. Compare them using Equals