### PR TITLE
feat: add default value for EnableAutoHistory

### DIFF
--- a/samples/AspNetCore5.0.MVC.EF.Blogs/Models/Model.cs
+++ b/samples/AspNetCore5.0.MVC.EF.Blogs/Models/Model.cs
@@ -14,7 +14,7 @@ namespace EFGetStarted.AspNetCore.NewDb.Models
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             // enable auto history functionality.
-            modelBuilder.EnableAutoHistory(changedMaxLength: null);
+            modelBuilder.EnableAutoHistory();
         }
 
     }

--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/ModelBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/ModelBuilderExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="modelBuilder">The <see cref="ModelBuilder"/> to enable auto history feature.</param>
         /// <param name="changedMaxLength">The maximum length of the 'Changed' column. <c>null</c> will use default setting 2048.</param>
         /// <returns>The <see cref="ModelBuilder"/> had enabled auto history feature.</returns>
-        public static ModelBuilder EnableAutoHistory(this ModelBuilder modelBuilder, int? changedMaxLength)
+        public static ModelBuilder EnableAutoHistory(this ModelBuilder modelBuilder, int? changedMaxLength = null)
         {
             return ModelBuilderExtensions.EnableAutoHistory<AutoHistory>(modelBuilder, o =>
             {


### PR DESCRIPTION
Sample from readme is not work:
```csharp
public class BloggingContext : DbContext
{
    public BloggingContext(DbContextOptions<BloggingContext> options)
        : base(options)
    { }

    public DbSet<Blog> Blogs { get; set; }
    public DbSet<Post> Posts { get; set; }

    protected override void OnModelCreating(ModelBuilder modelBuilder)
    {
        // enable auto history functionality.
        modelBuilder.EnableAutoHistory();
    }
}
```

Add missed argument default value for method  EnableAutoHistory.