### PR TITLE
Improve Readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,38 @@ public class BloggingContext : DbContext
 }
 ```
 
-3. Ensure AutoHistory in DbContext. This must be called before bloggingContext.SaveChanges() or bloggingContext.SaveChangesAsync().
+3. Ensure AutoHistory in DbContext. This must be called before `bloggingContext.SaveChanges()` or `bloggingContext.SaveChangesAsync()`.
 
 ```csharp
 bloggingContext.EnsureAutoHistory()
+```
+
+If you want to record data changes for all entities, just override `SaveChanges` and `SaveChangesAsync` methods and call `EnsureAutoHistory()` inside overridden version:
+```csharp
+public class BloggingContext : DbContext
+{
+    public BloggingContext(DbContextOptions<BloggingContext> options)
+        : base(options)
+    { }
+    
+    public override int SaveChanges()
+    {
+        this.EnsureAutoHistory();
+        return base.SaveChanges();
+    }
+    
+    public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = new CancellationToken())
+    {
+        this.EnsureAutoHistory();
+        return base.SaveChangesAsync(cancellationToken);
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        // enable auto history functionality.
+        modelBuilder.EnableAutoHistory();
+    }
+}
 ```
 
 # Use Custom AutoHistory Entity

--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/DbContextExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/DbContextExtensions.cs
@@ -55,9 +55,7 @@ namespace Microsoft.EntityFrameworkCore
                         {
                             continue;
                         }
-                        ((IDictionary<String, Object>)json)[prop.Metadata.Name] = prop.CurrentValue != null
-                            ? prop.CurrentValue
-                            : null;
+                        ((IDictionary<String, Object>)json)[prop.Metadata.Name] = prop.CurrentValue;
                     }
 
                     // REVIEW: what's the best way to set the RowId?
@@ -82,11 +80,9 @@ namespace Microsoft.EntityFrameworkCore
                                 }
                                 else
                                 {
-                                    databaseValues = databaseValues ?? entry.GetDatabaseValues();
+                                    databaseValues ??= entry.GetDatabaseValues();
                                     var originalValue = databaseValues.GetValue<object>(prop.Metadata.Name);
-                                    ((IDictionary<String, Object>)bef)[prop.Metadata.Name] = originalValue != null
-                                        ? originalValue
-                                        : null;
+                                    ((IDictionary<String, Object>)bef)[prop.Metadata.Name] = originalValue;
                                 }
                             }
                             else
@@ -94,9 +90,7 @@ namespace Microsoft.EntityFrameworkCore
                                 ((IDictionary<String, Object>)bef)[prop.Metadata.Name] = null;
                             }
 
-                            ((IDictionary<String, Object>)aft)[prop.Metadata.Name] = prop.CurrentValue != null
-                            ? prop.CurrentValue
-                            : null;
+                            ((IDictionary<String, Object>)aft)[prop.Metadata.Name] = prop.CurrentValue;
                         }
                     }
 
@@ -110,9 +104,7 @@ namespace Microsoft.EntityFrameworkCore
                 case EntityState.Deleted:
                     foreach (var prop in properties)
                     {
-                        ((IDictionary<String, Object>)json)[prop.Metadata.Name] = prop.OriginalValue != null
-                            ? prop.OriginalValue
-                            : null;
+                        ((IDictionary<String, Object>)json)[prop.Metadata.Name] = prop.OriginalValue;
                     }
                     history.RowId = entry.PrimaryKey();
                     history.Kind = EntityState.Deleted;


### PR DESCRIPTION
To record data changes for all entities without need calling `bloggingContext.EnsureAutoHistory()` before each `SaveChanges`:
```csharp
public override int SaveChanges()
{
    this.EnsureAutoHistory();
    return base.SaveChanges();
}
```